### PR TITLE
Fix coredev name highlight

### DIFF
--- a/trac-env/htdocs/tickethacks.js
+++ b/trac-env/htdocs/tickethacks.js
@@ -44,7 +44,7 @@ $(function() {
     var users = [];
 
     // Tickets first:
-    var attribution_regex = /by ([\w\-]+)/;
+    var attribution_regex = /by (\S+)/;
     $('#changelog h3.change').each(function() { 
         users.push(this.innerHTML.match(attribution_regex)[1]);
     });


### PR DESCRIPTION
The highlighting of coredev's names relies on a regex that uses `\w`.

Unfortunately, javascript does not support unicode with regexp, so this fails if a user with a non-ascii name has commented.

Since we're accessing the match regardless, an error is raised when that happens, which stops any further processing.

You can see an example of this on that page: https://code.djangoproject.com/ticket/19763 (note how none of the coredevs are highlighted; you can also see the error in the js console).

The fix in this pull request is not very robust either. It will work on non-ascii usernames but it could yield incorrect results if a user's name contain whitespace.
