### PR TITLE
Fix #20457: Always display the current year in the footer.

### DIFF
--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -34,7 +34,7 @@
           </div>
         </div>
         <div id="django-footer">
-          <p>&copy; 2005-2012 <a href="https://www.djangoproject.com/foundation/">Django Software Foundation</a> unless otherwise noted. Django is a registered trademark of the Django Software Foundation.
+          <p>&copy; 2005-${date.today().year} <a href="https://www.djangoproject.com/foundation/">Django Software Foundation</a> unless otherwise noted. Django is a registered trademark of the Django Software Foundation.
           <a href="http://mediatemple.net/">Linux Web hosting</a> graciously provided by Media Temple.
           </p>
         </div>


### PR DESCRIPTION
I experimented with a local trac instance and found that it provides the python `datetime.date` class in the context.

I couldn't find a documentation on exactly what is available in the context so I don't know if this is reliable but it does seem to work.
