### PR TITLE
Fixed #22127 -- Reverse default ordering in Trac's ticket list

### DIFF
--- a/trac-env/conf/trac.ini
+++ b/trac-env/conf/trac.ini
@@ -116,8 +116,8 @@ name = Django
 url = https://code.djangoproject.com/
 
 [query]
-default_query = status!=closed
-default_anonymous_query = status!=closed
+default_query = status!=closed&desc=1
+default_anonymous_query = status!=closed&desc=1
 
 [repositories]
 .dir = /home/trac/django-mirror


### PR DESCRIPTION
https://code.djangoproject.com/ticket/22127

As trac is rather a behemoth to install, I have not tested this patch myself. However, based on http://trac.edgewall.org/changeset/7553 and http://trac.edgewall.org/wiki/TicketQuery, this should be the correct change.
