### PR TITLE
Clarified instructions for opening issues on ancillary repos

### DIFF
--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -28,8 +28,10 @@
           <a href="https://docs.djangoproject.com/en/dev/internals/contributing/localizing/#translations">bug reports on translations</a>.
         </li>
         <li>
-          Please <a href="https://github.com/django/djangoproject.com/issues">create an issue on GitHub</a>
-          for issues with our web site (www.djangoproject.com) or with Trac (code.djangoproject.com).
+          Report issues with our web site (www.djangoproject.com) in <a href="https://github.com/django/djangoproject.com/issues">its GitHub issue tracker</a>.
+        </li>
+        <li>
+          Report issues with our bug tracker (code.djangoproject.com) in <a href="https://github.com/django/code.djangoproject.com/issues">its GitHub issue tracker</a>.
         </li>
         <li>
           Follow our


### PR DESCRIPTION
This might help to close #32.

I researched overriding Trac's error template to change the "Create" button's `href`, and it seems non-trivial. So it seems like two options available are:

1. Use jQuery to rewrite the button's `href` on page load
2. Clarify the instructions

This patch implements option 2.

Regardless of it's relation to #32, I think this patch is an improvement since it links to both issue trackers.

### Before

![screen shot 2015-04-25 at 11 47 14 pm](https://cloud.githubusercontent.com/assets/101698/7335981/92bf0f42-eba8-11e4-802f-c9cbf96b7ae5.png)

### After

![screen shot 2015-04-25 at 11 48 49 pm](https://cloud.githubusercontent.com/assets/101698/7335982/98b0fd34-eba8-11e4-8318-bf3884c2dbbe.png)
