### PR TITLE
Fixed #39 -- Added a warning for accounts without an email address.

### DIFF
--- a/trac-env/templates/site.html
+++ b/trac-env/templates/site.html
@@ -99,6 +99,12 @@
     <py:if test="req.environ['PATH_INFO'] != '/'">
       <div class="container full-width">
         <div role="main">
+          <py:if test="req.authname != 'anonymous' and not req.session.email">
+            <div class="system-message" id="warning">
+              Add an email address on the <a href="${req.href.prefs()}">Preferences</a>
+              page to receive updates on tickets you own, have created, or been CCed on.
+            </div>
+          </py:if>
           ${select('./div[@id="banner"]/div[@id="metanav"]')}
           ${select('./div[@id="mainnav"]')}
           ${select('./div[@id="main"]')}


### PR DESCRIPTION
It might work.

![msg](https://cloud.githubusercontent.com/assets/411869/10114489/4f47ed1c-63bf-11e5-98a1-5a5bba8fd0fb.png)
