### PR TITLE
Align Trac container with django headers #65

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -43,7 +43,7 @@ div.trac-content {
 }
 
 .full-width [role="main"] {
-  max-width: 960px;
+  max-width: 1400px;
 }
 
 #changelog h3 {


### PR DESCRIPTION
Trac tickets are not aligned with headers:
![tickets-screen0](https://cloud.githubusercontent.com/assets/321391/17232569/0858145a-5521-11e6-8ea2-d899812caf4c.png)

Headers are set to be 1400px, but ticket container is only 960px, also Track tickets table also overflow 960px. Looks a bit messy.

![tickets-screen1](https://cloud.githubusercontent.com/assets/321391/17232617/468541da-5521-11e6-9083-eb9f278fc4db.png)

After this small fix it looks nicely aligned:

![tickets-screen2](https://cloud.githubusercontent.com/assets/321391/17232630/5785010a-5521-11e6-9c72-624602b64ffb.png)

