### PR TITLE
Fixed inconsistent styling of logout button in metanav

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -176,6 +176,19 @@ div[role="main"]{
         }
       }
     }
+
+    form.trac-logout {
+      button {
+        color: $green;
+        border-bottom: 0;
+
+        &:hover {
+          background-color: inherit;
+          color: $green;
+          text-decoration: underline;
+        }
+      }
+    }
   }
 
   #mainnav {


### PR DESCRIPTION
Before (normal, hover)

![before_normal](https://cloud.githubusercontent.com/assets/6345/18994012/3625c5c6-8726-11e6-99ba-b67932596885.png)
![before_hover](https://cloud.githubusercontent.com/assets/6345/18994011/36236d94-8726-11e6-825a-d7057b65f3db.png)

After (normal, hover)

![after_normal](https://cloud.githubusercontent.com/assets/6345/18994010/3621c4a8-8726-11e6-85bd-33f41db2c3c0.png)
![after_hover](https://cloud.githubusercontent.com/assets/6345/18994009/3621aa22-8726-11e6-8642-a807ab7ce82d.png)

I was not able to actually test this locally because I did not manage to set up authentication in my local trac but I made the screenshots by applying the suggested changes directly in my web browser.