### PR TITLE
Removed yellow backgrounds introduced with new Trac version

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -21,6 +21,12 @@ body, th, tr { // reset trac default
   }
 }
 
+h1, h2, h3, h4, h5, h6, span {
+  &:target {
+    background: $green-very-light;
+  }
+}
+
 .inlinebuttons {
   input {
     border-radius: 5px;
@@ -57,6 +63,12 @@ div.trac-content {
 
 #changelog .inlinebuttons {
   float: none;
+}
+
+#changelog .changes {
+  background: $white;
+  border-color: $gray-line;
+  color: $text;
 }
 
 .trac-ticket-buttons {


### PR DESCRIPTION
Before:
![24941_ add_get_exclude _hook_to_basemodeladmin _ _django_-_2016-09-30_18 12 29](https://cloud.githubusercontent.com/assets/6345/18999327/4f5bd32a-873d-11e6-9fc3-ab9025dad23a.png)

After:
![24941_ add_get_exclude _hook_to_basemodeladmin _ _django_-_2016-09-30_18 14 48](https://cloud.githubusercontent.com/assets/6345/18999326/4f546bc6-873d-11e6-8b3b-b355db18ca70.png)

