### PR TITLE
Fix link color override

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -6,7 +6,7 @@ body, th, tr { // reset trac default
     line-height: normal;
 }
 
-:link, :visited {
+a:link, a:visited {
   border-bottom: 0;
   color: $green;
   &:hover{


### PR DESCRIPTION
Problem:
trachacks.scss is supposed to override styles from output.scss and trac.css

output.css defines rules for `a` and `a:visited`
trachacks.css (and trac.css) defines rules for `:link` and `:visited`

This results in unexpected results because:
regular links get trachacks styling because `:link` is more specific than `a`
visited links get output.css styling because `a:visited` is more specific than `:visited`

Solution:
Use `a:link` and `a:visited` in trachacks.css

Fixes #88 