### PR TITLE
Fixed "New ticket" crash when logging out.

### DIFF
--- a/DjangoPlugin/tracdjangoplugin/__init__.py
+++ b/DjangoPlugin/tracdjangoplugin/__init__.py
@@ -34,9 +34,11 @@ class CustomNewTicket(Component):
         return handler
 
     def post_process_request(self, req, template, data, content_type):
+        if data is None:
+            data = {}
         if req.path_info == '/newticket' and not data.get('preview_mode', False):
             simple_interface = 'TICKET_BATCH_MODIFY' not in req.perm
-            if simple_interface:
+            if simple_interface and 'fields' in data:
                 data['fields'] = [f for f in data['fields']
                                   if f['name'] not in self.hidden_fields]
             data['simple_interface'] = simple_interface


### PR DESCRIPTION
Noticed in Trac's logs:

```
Traceback (most recent call last):
  File "/home/www/trac/venv/local/lib/python2.7/site-packages/trac/web/main.py", line 280, in dispatch
    self._post_process_request(req)
  File "/home/www/trac/venv/local/lib/python2.7/site-packages/trac/web/main.py", line 480, in _post_process_request
    f.post_process_request(req, *(None,)*extra_arg_count)
  File "/home/www/trac/src/DjangoPlugin/tracdjangoplugin/__init__.py", line 37, in post_process_request
    if req.path_info == '/newticket' and not data.get('preview_mode', False):
AttributeError: 'NoneType' object has no attribute 'get'
```