### PR TITLE
Ensure that the Django auth trac plugin utilizes the correct pg port.

### DIFF
--- a/DjangoPlugin/tracdjangoplugin/settings.py
+++ b/DjangoPlugin/tracdjangoplugin/settings.py
@@ -12,6 +12,7 @@ DATABASES = {
         'NAME': 'djangoproject',
         'USER': 'djangoproject',
         'HOST': SECRETS.get('db_host', ''),
+        'PORT': SECRETS.get('db_port', 5432),
         'PASSWORD': SECRETS.get('db_password', ''),
     },
 }


### PR DESCRIPTION
I currently fixed this locally via iptables but we should deploy this before the next server reboot (and after the trac cache finished indexing)