### PR TITLE
Link to the proper favicon.

### DIFF
--- a/trac-env/conf/trac.ini
+++ b/trac-env/conf/trac.ini
@@ -134,7 +134,7 @@ always_notify_reporter = TicketReporterSubscriber
 [project]
 descr = The Web framework for perfectionists with deadlines.
 footer = 
-icon = site/favicon.ico
+icon = site/img/favicon.ico
 name = Django
 url = https://code.djangoproject.com/
 


### PR DESCRIPTION
The changes made in 8d832b3 repointed to an older lower res version.

Compare 

https://code.djangoproject.com/chrome/site/favicon.ico
![](https://code.djangoproject.com/chrome/site/favicon.ico)

to

https://code.djangoproject.com/chrome/site/img/favicon.ico
![](https://code.djangoproject.com/chrome/site/img/favicon.ico)