### PR TITLE
Update to Trac 1.6 and Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,21 +21,20 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - run: pip install "tinycss2>=1.2.0"
       - run: python noshadows.py --tests
 
   tracdjangoplugin:
-    runs-on: ubuntu-latest
-    container:
-      image: python:2.7.18-buster
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
       - name: Install requirements
         run: python -m pip install -r requirements.txt
-      - name: Install backport of unittest.mock
-        run: python -m pip install mock
       - name: Run tests
         run: python -m django test tracdjangoplugin.tests
         env:

--- a/DjangoPlugin/tracdjangoplugin/plugins.py
+++ b/DjangoPlugin/tracdjangoplugin/plugins.py
@@ -1,11 +1,10 @@
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from trac.core import Component, implements
 from trac.web.chrome import INavigationContributor
 from trac.web.api import IRequestFilter, IRequestHandler, RequestDone
 from trac.web.auth import LoginModule
 from trac.wiki.web_ui import WikiModule
-from trac.util import Markup
 from trac.util.html import tag
 from tracext.github import GitHubBrowser
 
@@ -82,7 +81,7 @@ class CustomNavigationBar(Component):
             (
                 "mainnav",
                 "custom_reports",
-                Markup('<a href="%s">Reports</a>' % req.href.wiki("Reports")),
+                tag.a("Reports", href=req.href.wiki("Reports")),
             ),
         ]
 

--- a/DjangoPlugin/tracdjangoplugin/tests.py
+++ b/DjangoPlugin/tracdjangoplugin/tests.py
@@ -1,9 +1,6 @@
 from functools import partial
 
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
+from unittest.mock import Mock
 
 from django.core.signals import request_finished, request_started
 from django.contrib.auth.forms import AuthenticationForm

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,15 @@ Using Docker
 
 * Install Docker
 * ``pip install docker-compose``
+* Create a ``secrets.json`` file at the root of the repository (next to `Dockerfile`), containing
+  something like::
+
+    {
+      "secret_key": "xyz",
+      "db_host": "localhost",
+      "db_password": "secret"
+    }
+
 * ``docker-compose up --build``
 * Follow instructions above to create/load the DB, grant permissions, create the
   config, etc. For example::
@@ -28,7 +37,7 @@ Using Docker
     docker-compose up --build
     export DATABASE_URL=postgres://code.djangoproject:secret@db/code.djangoproject
     docker-compose exec -T db psql $DATABASE_URL < ../djangoproject.com/tracdb/trac.sql
-    docker-compose exec trac /venv/bin/trac-admin /code/trac-env/ permission add anonymous TRAC_ADMIN
+    docker-compose exec trac trac-admin /code/trac-env/ permission add anonymous TRAC_ADMIN
 
 Using Podman
 ------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,10 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    command: ["/venv/bin/tracd", "--port", "9000", "-s", "trac-env"]
+    command: ["gunicorn", "--bind", "0:9000", "--reload", "tracdjangoplugin.wsgi"]
     environment:
      - TRAC_INI_database=postgres://code.djangoproject:secret@db/code.djangoproject
+     - SECRETS_FILE=/code/secrets.json
     volumes:
       - ./:/code/
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,12 +10,12 @@ set -e
 #   database = postgres://...
 
 for var in "${!TRAC_INI_@}"; do
-    sed -i "s;^${var:9} = .*;${var:9} = ${!var};" trac-env/conf/trac.ini
+    sed -i "s;^${var:9} = .*;${var:9} = ${!var};" /code/trac-env/conf/trac.ini
 done
 
 if [ "x$TRAC_COLLECT_STATIC" = 'xon' ]; then
     # Collect trac static files to be served by nginx
-    /venv/bin/trac-admin ./trac-env/ deploy ./static/
+    trac-admin /code/trac-env/ deploy ./static/
 fi
 
 exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,17 @@
 # spam-filter doesn't work without babel (but somehow doesn't list it in its requirements)
-Trac[pygments, babel]==1.4.4
+Trac[pygments, babel]==1.6.0
 dnspython==1.15
-spambayes == 1.1b1
-psycopg2==2.7.6.1 --no-binary=psycopg2
-docutils==0.14
+psycopg2==2.9.9 --no-binary=psycopg2
 Django==1.11.29
-libsass==0.17.0
-Genshi==0.7.7  # still required by some plugins
+libsass==0.23.0
 
 # Trac plugins
-https://trac.edgewall.org/browser/plugins/1.4/spam-filter?format=zip
-# TracXMLRPC from PyPI does not (yet) have a 1.2.0 release (compatible with Trac 1.4)
+https://trac.edgewall.org/browser/plugins/trunk/spam-filter?rev=17752&format=zip
+# TracXMLRPC from PyPI does not (yet) have a 1.2.0 release (compatible with Trac >=1.4)
 https://trac-hacks.org/browser/xmlrpcplugin/trunk?rev=18591&format=zip
 
-oauthlib==2.1.0
-requests==2.20.1
-requests-oauthlib==1.0.0
-trac-github==2.3
+# No pypi release compatible with trac 1.6 yet
+trac-github[oauth] @ git+https://github.com/bmispelon/trac-github.git@trac-1.6-py3
 
 gunicorn==19.10.0
 sentry-sdk==1.11.0


### PR DESCRIPTION
I think this PR is finally ready:

- our small test suite now runs (and passes) on Python 3.8 (see my first comment for an explanation why i skipped 3.7)
- I've tested locally and the site seems to still work
- The docker image builds and I was able to run it locally as well (and I haven't made any changes to volumes which would impact its deployment in production as far as i know). I used the image from djangoproject.com as a base, which is why the diff is a bit big on this one.
- I've used my fork of `trac-github` in the requirements while we wait for a new release (my PR is still pending: https://github.com/trac-hacks/trac-github/pull/141)
- This new version of Trac does not require any database upgrade (no need to run any special command)
- The `noshadows` script didn't detect new CSS that might need fixing

Shall we move into the future of Python3? 🐍 🐍 🐍 

Refs #148 