### PR TITLE
Fixed leftover genshi syntax in template

### DIFF
--- a/trac-env/templates/site_head.html
+++ b/trac-env/templates/site_head.html
@@ -10,6 +10,6 @@
     }
   });
 </script>
-<py:if test="req.environ['PATH_INFO'].startswith('/ticket/')">
+# if req.path_info.startswith('/ticket/'):
   <script type="text/javascript" src="${href.chrome('site/tickethacks.js')}"></script>
-</py:if>
+# endif


### PR DESCRIPTION
I must have messed up something during a rebase, sorry.

The file `tickethack.js` ended up being included on all pages, so things kept working. But it's possible this might be the cause of some of the js errors (something about github rate limiting) in the console.