### PR TITLE
Fixed #150 -- Fixed error when logging out

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,10 @@ https://trac-hacks.org/browser/xmlrpcplugin/trunk?rev=18591&format=zip
 oauthlib==2.1.0
 requests==2.20.1
 requests-oauthlib==1.0.0
-trac-github==2.3
+# trac-github is unmaintained at this time and not compatible with Trac 1.4
+# See issue https://github.com/trac-hacks/trac-github/issues/136 for example
+# So obviously the solution is a fork, this one will surely never go unmaintained
+trac-github @ git+https://github.com/bmispelon/trac-github.git@trac-1.4
 
 gunicorn==19.10.0
 sentry-sdk==1.11.0


### PR DESCRIPTION
Turns out the trac-github extension is not really maintained at the moment and is not compatible with Trac 1.4.

The solution I'm offering here (hopefully only temporarily) is that I've forked the extension and fixed the logout issue. The test suite on trac-github still has a lot of failures and I haven't gone through to check if it might be something that affects us, but the logout button/link seems to work on my local version (testing is limited and approximate because it's quite hard to replicate github login locally unfortunately).