### PR TITLE
Fix spamfilter admin configuration page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-Trac==1.4.4
-Pygments==2.5.2
+Trac[pygments]==1.4.4
 dnspython==1.15
 spambayes == 1.1b1
 psycopg2==2.7.6.1 --no-binary=psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Trac[pygments]==1.4.4
+# spam-filter doesn't work without babel (but somehow doesn't list it in its requirements)
+Trac[pygments, babel]==1.4.4
 dnspython==1.15
 spambayes == 1.1b1
 psycopg2==2.7.6.1 --no-binary=psycopg2


### PR DESCRIPTION
It seems that `spam-filter` has an implicit dependency to `Babel`.

This fixes the error on the "Configuration" admin page, but it doesn't fix the blank pages (I observe the same problem locally).