### PR TITLE
Fixed login/logout/logged as items in metanav

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,7 @@ https://trac-hacks.org/browser/xmlrpcplugin/trunk?rev=18591&format=zip
 oauthlib==2.1.0
 requests==2.20.1
 requests-oauthlib==1.0.0
-# trac-github is unmaintained at this time and not compatible with Trac 1.4
-# See issue https://github.com/trac-hacks/trac-github/issues/136 for example
-# So obviously the solution is a fork, this one will surely never go unmaintained
-trac-github @ git+https://github.com/bmispelon/trac-github.git@trac-1.4
+trac-github==2.3
 
 gunicorn==19.10.0
 sentry-sdk==1.11.0

--- a/trac-env/conf/trac.ini
+++ b/trac-env/conf/trac.ini
@@ -92,13 +92,8 @@ timeline.order = 4.0
 wiki.order = 5.0
 
 [metanav]
-about = disabled
-github_login.order = 1.0
-help = disabled
-login.label = DjangoProject Login
-login.order = 2.0
-logout.order = 3.0
-prefs.order = 4.0
+; The metanav is hardcoded in templates/django_theme.html
+; because it was too hard to make the login plugins play nice with each other
 
 [mimeviewer]
 enscript_modes = text/x-dylan:dylan:4

--- a/trac-env/templates/django_theme.html
+++ b/trac-env/templates/django_theme.html
@@ -17,7 +17,26 @@
 
 # macro main()
 <div role="main">
-  ${navigation('metanav')}
+  <div id="metanav" class="nav">
+    <ul>
+      # if req.is_authenticated:
+        <li>Logged in as ${req.authname}</li>
+        <li>
+          <form action="/github/logout" method="post" id="logout" class="trac-logout">
+            <button type="submit">Logout</button>
+            <input type="hidden" name="__FORM_TOKEN" value="${req.form_token}">
+          </form>
+        </li>
+      # else
+        <li><a href="/github/login">GitHub Login</a></li>
+        <li><a href="/login">DjangoProject Login</a></li>
+      # endif
+      <li><a href="${req.href.prefs()}">Preferences</a></li>
+      # if req.perm.has_permission('XML_RPC'):
+        <li><a href="${req.href.rpc()}">API</a></li>
+      # endif
+    </ul>
+  </div>
   ${navigation('mainnav')}
   <div id="main" ${{'class': {
                     'uisymbols': req.session.get('ui.use_symbols'),


### PR DESCRIPTION
Most of the issues were caused by Trac's clever plugin system where classes implementing `INavigationContributor` all contribute to the metanav. Plugins can then override existing links by making sure they pass the same name (second element in the yielded tuple in `get_navigation_items()`). On top of that, trac.ini can override any item by specifying a <item name>.label configuration.

Rather than trying to figure this all out, I've opted to hardcode the navigation menu in the HTML. This has the nice side-effect of removing the dependency on the forked trac-github.

This commit therefore includes a revert of d8760ada04eecf5833c1fd4a13994f30a4858acd.

Fixes #51