### PR TITLE
Added margin between comment title and property change table

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -90,6 +90,10 @@ div.trac-content {
   float: none;
 }
 
+#changelog .trac-change-panel {
+  margin-top: 0;
+}
+
 #ticketchange .changes, #changelog .changes {
   background: $white;
   border-color: $gray-line;


### PR DESCRIPTION
Fixes #169

Here's how it looks without `TRAC_ADMIN` permissions (that is for most users):
![Screenshot 2024-01-28 at 00-17-04 #1 (Is this red ) – Django](https://github.com/django/code.djangoproject.com/assets/6345/f2877b45-4c14-4f96-8e06-8488ac5bfc46)


And with `TRAC_ADMIN`:
![Screenshot 2024-01-28 at 00-16-28 #1 (Is this red ) – Django](https://github.com/django/code.djangoproject.com/assets/6345/757bf5a9-2c1f-4cbc-a90b-774446e7df5c)
