### PR TITLE
add modernizr svg class manually to utilize SVGs in CSS #173

### DIFF
--- a/trac-env/templates/django_theme.html
+++ b/trac-env/templates/django_theme.html
@@ -83,7 +83,7 @@
 </head>
 
 {#  we don't use the modernizer js lib anymore, but the css still uses some classes from it #}
-<body class="mdzr-boxshadow">
+<body class="mdzr-boxshadow mdzr-svg">
   # block body
 
   # include 'site_header.html' ignore missing


### PR DESCRIPTION
Modernizr JavaScript library was removed in 43d9616 due to the fact that the CSS class `mdzr-svg` is missing from the markup and the SVG images defined in the output.css are no longer used. This leads to visual regression compared to other parts of the djangoproject.com website on high-dpi devices (blurry images), i.e. header/footer logos.

Other Modernizr classes used in code.djangoproject.com seem to be `.mdzr-borderradius`, `.mdzr-cssanimations` but those appear only in the output.css and seem to be used on the djangoproject.com home page and not here. `.mdzr-no-borderradius` is used as well, but that seems irrelevant, since all browsers should support border-radius.