### PR TITLE
Properly closed database connections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install requirements
         run: python -m pip install -r requirements.txt
+      - name: Install backport of unittest.mock
+        run: python -m pip install mock
       - name: Run tests
         run: python -m django test tracdjangoplugin.tests
         env:

--- a/DjangoPlugin/tracdjangoplugin/middlewares.py
+++ b/DjangoPlugin/tracdjangoplugin/middlewares.py
@@ -1,0 +1,22 @@
+from django.core.signals import request_finished, request_started
+
+
+class DjangoDBManagementMiddleware:
+    """
+    A simple WSGI middleware that manually manages opening/closing db connections.
+
+    Django normally does that as part of its own middleware chain, but we're using Trac's middleware
+    so we must do this by hand.
+    This hopefully prevents open connections from piling up.
+    """
+
+    def __init__(self, application):
+        self.application = application
+
+    def __call__(self, environ, start_response):
+        request_started.send(sender=self.__class__)
+        try:
+            for data in self.application(environ, start_response):
+                yield data
+        finally:
+            request_finished.send(sender=self.__class__)

--- a/DjangoPlugin/tracdjangoplugin/wsgi.py
+++ b/DjangoPlugin/tracdjangoplugin/wsgi.py
@@ -12,6 +12,11 @@ django.setup()
 # Python 3 would perform better here, but we are still on 2.7 for Trac, so leak fds for now.
 from tracopt.versioncontrol.git import PyGIT
 
+from .middlewares import DjangoDBManagementMiddleware
+
+
+application = DjangoDBManagementMiddleware(application)
+
 PyGIT.close_fds = False
 
 trac_dsn = os.getenv("SENTRY_DSN")


### PR DESCRIPTION
eb16ed0b13ec81d1c798599683ea7fba391c2053 removed (among a lot of other things) a call to close_old_connections(), mostly because I hadn't understood what that was doing exactly.
Since then I've been kept awake at night with the sense of dread that old database connections were piling up unclosed on Django's server.

So I wrote this wsgi middleware that should hopefully restore balance in the universe, or at least close db connections.