### PR TITLE
Fix Typo in site_footer.html

### DIFF
--- a/trac-env/templates/site_footer.html
+++ b/trac-env/templates/site_footer.html
@@ -72,7 +72,7 @@
         <li class="design"><span>Design by</span> <a class="threespot" href="http://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/"></a></li>
       </ul>
       <p class="copyright">&copy; 2005-${date.today().year}
-        <a href="https://djangoproject.com/foundation/"> Django SoftwareFoundation</a>
+        <a href="https://djangoproject.com/foundation/"> Django Software Foundation</a>
         unless otherwise noted. Django is a
         <a href="https://djangoproject.com/trademarks/">registered trademark</a>
         of the Django Software Foundation.


### PR DESCRIPTION
Changes `Django SoftwareFoundation` -> `Django Software Foundation`

https://www.djangoproject.com shows `Django Software Foundation` not `Django SoftwareFoundation`  as well.
![image](https://github.com/django/code.djangoproject.com/assets/77439837/9e7876f0-de42-49a2-a4cf-b872b6a31614)

https://code.djangoproject.com/
![image](https://github.com/django/code.djangoproject.com/assets/77439837/9e42d386-79f3-4e37-9eb0-d4fc42527643)