### PR TITLE
Added missing requirement for tracspamfilter plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ libsass==0.23.0
 
 # Trac plugins
 https://trac.edgewall.org/browser/plugins/trunk/spam-filter?rev=17752&format=zip
+filelock==3.13.1  # required for running tracspamfilter.filters.bayes
 # TracXMLRPC from PyPI does not (yet) have a 1.2.0 release (compatible with Trac >=1.4)
 https://trac-hacks.org/browser/xmlrpcplugin/trunk?rev=18591&format=zip
 


### PR DESCRIPTION
While investigating something else I happened to turn on logging in `trac.ini` (changed `log_type` to `stdout`) and saw this line in the console while running my local version:
```
01:30:52 PM Trac[loader] ERROR: Skipping "spamfilter.bayes = tracspamfilter.filters.bayes": ModuleNotFoundError: No module named 'filelock'
```

So it seems the cause for the latest spam waves might have been that one plugin was silently being skipped because of a missing dependency 😞 

After installing the `filelock` package the error goes away, which I assume means the plugin is active again 🤞🏻 