### PR TITLE
Updated to Django 3.2.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
           python-version: '3.8'
       - run: pip install "tinycss2>=1.2.0"
       - run: python noshadows.py --tests
+        env:
+          PYTHONWARNINGS: error
 
   tracdjangoplugin:
     runs-on: ubuntu-20.04
@@ -39,6 +41,7 @@ jobs:
         run: python -m django test tracdjangoplugin.tests
         env:
           DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
+          PYTHONWARNINGS: error
 
   traccheck:
     runs-on: ubuntu-20.04
@@ -53,6 +56,8 @@ jobs:
       - run: python traccheck.py lint trac-env/
         env:
           DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
+          PYTHONWARNINGS: error
       - run: python traccheck.py components --check .TRACFREEZE.txt trac-env/
         env:
           DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
+          PYTHONWARNINGS: error

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # spam-filter doesn't work without babel (but somehow doesn't list it in its requirements)
 Trac[pygments, babel]==1.6.0
 psycopg2==2.9.9 --no-binary=psycopg2
-Django==1.11.29
+Django==3.2.24
 libsass==0.23.0
 
 # Trac plugins


### PR DESCRIPTION
Because we use so little of Django, I figured it was fine to make the jump all at once. I would still suggest merging #181 first, just for the extra piece of mind.

I activated `PYTHONWARNINGS=error` in CI and fixed the deprecation warnings that came up. This will make the future update to Django >= 4.0 easier (we'll have to work that one in parallel with django/djangoproject.com).

Because we don't manage any db from Django there is no need for any operation after deploying this.