### PR TITLE
Upgraded sentry-sdk to 1.40.4 (latest)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ https://trac-hacks.org/browser/xmlrpcplugin/trunk?rev=18591&format=zip
 trac-github[oauth] @ git+https://github.com/bmispelon/trac-github.git@trac-1.6-py3
 
 gunicorn==19.10.0
-sentry-sdk==1.11.0
+sentry-sdk==1.40.4
 
 -e ./DjangoPlugin


### PR DESCRIPTION
According to https://docs.sentry.io/platforms/python/integrations/django/#supported-versions this version of Sentry is not compatible with Django 1.11, so we need to merge #183 first.