### PR TITLE
Restored support for restructuredtext on wiki pages

### DIFF
--- a/.TRACFREEZE.txt
+++ b/.TRACFREEZE.txt
@@ -22,6 +22,7 @@ trac.mimeview.api.plaintextrenderer
 trac.mimeview.api.wikitextrenderer
 trac.mimeview.patch.patchrenderer
 trac.mimeview.pygments.pygmentsrenderer
+trac.mimeview.rst.restructuredtextrenderer
 trac.notification.api.notificationsystem
 trac.notification.mail.alwaysemailsubscriber
 trac.notification.mail.emaildistributor

--- a/DjangoPlugin/tracdjangoplugin/tests.py
+++ b/DjangoPlugin/tracdjangoplugin/tests.py
@@ -7,6 +7,10 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.models import User
 from django.test import SimpleTestCase, TestCase
 
+from trac.mimeview.api import Mimeview
+from trac.mimeview.rst import (
+    ReStructuredTextRenderer,  # noqa: needed for RSTWikiTestCase to work
+)
 from trac.test import EnvironmentStub, MockRequest
 from trac.web.api import RequestDone
 
@@ -228,3 +232,15 @@ class ReservedUsernamesComponentTestCase(TestCase):
         handler = object()
         retval = self.component.pre_process_request(request, handler=handler)
         self.assertIs(retval, handler)
+
+
+class RSTWikiTestCase(SimpleTestCase):
+    def test_wiki_can_render_rst(self):
+        renderer = Mimeview(EnvironmentStub())
+        output = renderer.render(
+            content="====\nTEST\n====\n", mimetype="text/x-rst", context=None
+        )
+        self.assertHTMLEqual(
+            str(output),
+            '<div class="document" id="test"><h1 class="title">TEST</h1></div>',
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # spam-filter doesn't work without babel (but somehow doesn't list it in its requirements)
-Trac[pygments, babel]==1.6.0
+# rest is needed to support wiki pages written in rst
+Trac[babel, pygments, rest]==1.6.0
 psycopg2==2.9.9 --no-binary=psycopg2
 Django==3.2.25
 libsass==0.23.0


### PR DESCRIPTION
The docutils dependency was removed by mistake in
d9356b48ed32d75436302e8738b03cfc08d38ccd.

Fixes #187