### PR TITLE
Fixed #189 -- Removed trac yellow background from comment editor textbox

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -191,6 +191,10 @@ blockquote.citation {
   margin-left: 0;
 }
 
+#trac-comment-editor textarea {
+  background: inherit;
+}
+
 #ticket {
   #ticketbox {
     background-color: $white;


### PR DESCRIPTION
Here's how it looks with the change:

![Screenshot 2024-04-03 at 22-48-40 #34406 (Add support for curved geometries in GeoDjango) – Django](https://github.com/django/code.djangoproject.com/assets/6345/3dde3499-3ad1-4a93-85a8-a125fcededa6)
