### PR TITLE
Fixed #114 -- Removed default owner for tickets

### DIFF
--- a/trac-env/conf/trac.ini
+++ b/trac-env/conf/trac.ini
@@ -195,6 +195,7 @@ authz_module_name =
 [ticket]
 default_component = Uncategorized
 default_milestone = 
+default_owner =
 default_priority = major
 default_type = bug / defect
 default_version = 5.0


### PR DESCRIPTION
The previous configuration would display a "< default >" user as a value in the dropdown on ticket creation, and using that value would then assign the ticket to the component's owner. But we don't use component owners, so the result was that the ticket was assigned to an empty string.