### PR TITLE
Upgraded to Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ permissions:
 
 env:
   DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
+  # passlib has a conditional import for `crypt` which is going away in python 3.13
+  # and therefore throwing warnings
   PYTHONWARNINGS: >
     error,
     default:::passlib.utils,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,51 +13,56 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
+  PYTHONWARNINGS: >
+    error,
+    default:::passlib.utils,
+
 jobs:
   noshadows:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - run: pip install "tinycss2>=1.2.0"
       - run: python noshadows.py --tests
-        env:
-          PYTHONWARNINGS: error
 
   tracdjangoplugin:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
+      - name: Install system package dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install subversion
       - name: Install requirements
         run: python -m pip install -r requirements.txt
       - name: Run tests
         run: python -m django test tracdjangoplugin.tests
-        env:
-          DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
-          PYTHONWARNINGS: error
 
   traccheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
+      - name: Install system package dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install subversion
       - name: Install requirements
         run: python -m pip install -r requirements.txt
-      - run: python traccheck.py lint trac-env/
-        env:
-          DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
-          PYTHONWARNINGS: error
-      - run: python traccheck.py components --check .TRACFREEZE.txt trac-env/
-        env:
-          DJANGO_SETTINGS_MODULE: tracdjangoplugin.settings_tests
-          PYTHONWARNINGS: error
+      - name: Lint Trac configuration
+        run: python traccheck.py lint trac-env/
+      - name: Check frozen Trac components
+        run: python traccheck.py components --check .TRACFREEZE.txt trac-env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.8-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # set work directory
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.12-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 # set work directory
 WORKDIR /code

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ psycopg2==2.9.9 --no-binary=psycopg2
 Django==4.2.16
 libsass==0.23.0
 
+# Optional Trac dependencies that make DeprecationWarning go away
+multipart==1.1.0
+passlib==1.7.4
+
 # Trac plugins
 TracSpamFilter[dns,spambayes] @ svn+https://svn.edgewall.org/repos/trac/plugins/trunk/spam-filter@17766
 TracDragDrop @ svn+https://trac-hacks.org/svn/tracdragdropplugin/0.12@18635

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@ psycopg2==2.9.9 --no-binary=psycopg2
 Django==4.2.16
 libsass==0.23.0
 
-# Optional Trac dependencies that make DeprecationWarning go away
+# Optional Trac dependencies that make DeprecationWarning go away.
+# When upgrading Trac or Python, check if these dependencies are still needed
+# by uninstalling them and running the test suite (or CI) with PYTHONWARNINGS=error
 multipart==1.1.0
 passlib==1.7.4
 


### PR DESCRIPTION
As I wrote in https://github.com/django/code.djangoproject.com/pull/219#issuecomment-2452482455, I think the best (well, least bad) option we have is to run Python 3.11.