### PR TITLE
Autofix: PR status only take the first check into account

### DIFF
--- a/trac-env/htdocs/tickethacks.js
+++ b/trac-env/htdocs/tickethacks.js
@@ -121,8 +121,19 @@ $(function() {
                                 async: false,
                                 success: function (data) {
                                     if (data.length > 0) {
-                                        build_state = data[0].state;
-                                        link_text += " build:" + build_state;
+                                        var statuses = data.map(function(status) {
+                                            return status.state;
+                                        });
+                                        if (statuses.includes('pending')) {
+                                            build_state = 'building';
+                                        } else if (statuses.includes('failure') || statuses.includes('error')) {
+                                            build_state = 'error';
+                                        } else if (statuses.every(function(status) { return status === 'success'; })) {
+                                            build_state = 'success';
+                                        } else {
+                                            build_state = 'unknown';
+                                        }
+                                        link_text += ' build:' + build_state;
                                     }
                                 }
                             });


### PR DESCRIPTION
Modified the logic to determine the build status of a pull request. Now it considers all checks, setting the status to 'building' if any check is in progress, 'error' if any check has failed, and 'success' only if all checks have passed. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    