### PR TITLE
Add a link to Individual membership in the site footer

### DIFF
--- a/trac-env/templates/site_footer.html
+++ b/trac-env/templates/site_footer.html
@@ -22,6 +22,7 @@
             <li><a href="https://docs.djangoproject.com/en/dev/internals/contributing/">Contribute to Django</a></li>
             <li><a href="https://docs.djangoproject.com/en/dev/internals/contributing/bugs-and-features/#reporting-security-issues">Submit a Bug</a></li>
             <li><a href="https://docs.djangoproject.com/en/dev/internals/security/">Report a Security Issue</a></li>
+            <li><a href="https://www.djangoproject.com/foundation/individual-members/">Individual membership</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
This is a companion change to go along with the footer updates made to the main djangoproject.com website at https://github.com/django/djangoproject.com/pull/1726/.