### PR TITLE
Used commit author and not committer when recording changesets

### DIFF
--- a/trac-env/conf/trac.ini
+++ b/trac-env/conf/trac.ini
@@ -63,6 +63,8 @@ projects_url =
 [git]
 cached_repository = enabled
 persistent_cache = enabled
+# We want authors listed, not committers:
+use_committer_id = disabled
 
 [header_logo]
 alt = Django


### PR DESCRIPTION
THis should enable us to extract commit statistics per user.

See https://github.com/django/djangoproject.com/issues/1744
