### PR TITLE
Removed obsolete version element from compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   trac:
     image: ghcr.io/django/code.djangoproject.com:latest


### PR DESCRIPTION
As requested in <https://github.com/django/djangoproject.com/pull/1802>, this should finalize the move to Compose V2.