### PR TITLE
Rename postgres database engine to stop using an alias

### DIFF
--- a/DjangoPlugin/tracdjangoplugin/settings.py
+++ b/DjangoPlugin/tracdjangoplugin/settings.py
@@ -11,7 +11,7 @@ DEBUG = False
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "ENGINE": "django.db.backends.postgresql",
         "NAME": "djangoproject",
         "USER": "djangoproject",
         "HOST": SECRETS.get("db_host", ""),


### PR DESCRIPTION
Coming from https://github.com/django/code.djangoproject.com/pull/238#discussion_r1873906665 

I saw this change under https://github.com/django/code.djangoproject.com/pull/223, and it was rejected, but as @bmispelon pointed out, the database engine name part can be merged because it's just an alias.

`postgresql_psycopg2` backend renamed to `postgresql` in Django 1.9:
- https://code.djangoproject.com/ticket/25175
- https://github.com/django/django/commit/ec9004728ee136e3b7e2b7cd2610203e16b6ce9b