### PR TITLE
Removed references to #django IRC.

### DIFF
--- a/trac-env/templates/django_theme.html
+++ b/trac-env/templates/django_theme.html
@@ -122,7 +122,7 @@
           <dt><a href="https://dashboard.djangoproject.com/">Django Dashboard</a></dt>
           <dd>Confused about Trac's filtering system? This dashboard shows easy-to-read metrics and has links to pre-set filters to get you started.</dd>
 
-          <dt><a href="irc://irc.freenode.net/django-dev">#django-dev IRC channel</a></dt>
+          <dt><a href="https://discord.gg/xcRH6mN4fa">Django Discord server (#contributing-getting-started)</a></dt>
           <dd>Questions about a ticket? Stuck on how to write a unit test for your pull request? Come chat with us!</dd>
         </dl>
       </div>

--- a/trac-env/templates/site_footer.html
+++ b/trac-env/templates/site_footer.html
@@ -29,7 +29,6 @@
           <h2>Get Help</h2>
           <ul>
             <li><a href="https://docs.djangoproject.com/en/dev/faq/">Getting Help FAQ</a></li>
-            <li><a href="irc://irc.libera.chat/django">#django IRC channel</a></li>
             <li><a href="https://discord.gg/xcRH6mN4fa" target="_blank">Django Discord</a></li>
             <li><a href="https://forum.djangoproject.com/" target="_blank">Official Django Forum</a></li>
           </ul>


### PR DESCRIPTION
Following https://forum.djangoproject.com/t/proposal-retire-irc/37129 and https://code.djangoproject.com/ticket/35999, these are my suggested updates for Trac.

I have chosen to:

- update IRC to the Django Discord in the "come chat with us"
- align the footer to https://github.com/django/djangoproject.com/pull/1821