### PR TITLE
Disabled spamhaus.org antispam check

### DIFF
--- a/trac-env/conf/trac.ini
+++ b/trac-env/conf/trac.ini
@@ -187,6 +187,8 @@ trap_karma = 10
 trust_authenticated = disabled
 typepad_karma = 5
 url_blacklist_karma = 3
+# Remove spamhaus from the default list (doesn't work on our current prod setup):
+url_blacklist_servers = urired.spameatingmonkey.net,multi.surbl.org
 
 [svn]
 authz_file = 


### PR DESCRIPTION
The service doesn't seem to work, possibly because
of the containerization.

Refs #245
