### PR TITLE
Recommend to users that features go to the forum first

### DIFF
--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -9,8 +9,12 @@
         Contact <a href="mailto:security@djangoproject.com">security@djangoproject.com</a> instead.</strong>
     </li>
     <li>
-      Report bugs and suggest features in Django itself (or its
-      documentation) using this ticket tracker.
+      Report bugs and suggest documentation changes using this ticket tracker.
+    </li>
+    <li>
+      New feature proposals should first be discussed on the <a href="https://forum.djangoproject.com/">Django Forum</a>.
+      Once feedback has been gathered, you can use this ticket tracker to open a ticket for the new feature.
+      Please include links to relevant discussions from the forum (or other sources).
     </li>
     <li>
       Don't use the ticket system for

--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -12,7 +12,7 @@
       Report bugs and suggest documentation changes using this ticket tracker.
     </li>
     <li>
-      New feature proposals should first be discussed on the <a href="https://forum.djangoproject.com/">Django Forum</a>.
+      New feature proposals should first be discussed on the <a href="https://forum.djangoproject.com/c/internals/5">Django Forum</a>.
       Once feedback has been gathered, you can use this ticket tracker to open a ticket for the new feature.
       Please include links to relevant discussions from the forum (or other sources).
     </li>


### PR DESCRIPTION
Closes #249

I suggested this one - so I thought I'd actually follow up with a pull request for it (thanks to @benjaoming for opening the issue here).

This is **not** a process change, but updating the text in Trac to reflect documentation elsewhere, and what happens to most feature requests anyway. The [Requesting features](https://docs.djangoproject.com/en/5.1/internals/contributing/bugs-and-features/#requesting-features) section in the docs mentions this as the preferred route to suggest new features. Quite a lot of [closed feature requests](https://code.djangoproject.com/query?description=~&status=closed&type=New+feature&order=id&desc=1&col=id&col=summary&col=owner&col=type&col=component) are coming through to Trac with a recommendation to use the forum - as that's the preferred process.

I've reworded the text from the original suggestion (might be easier to read). I've intentionally left out anything about suggesting smaller improvements being started in Trac first - as regular contributors would probably either be aware of the process, or have enough consensus from other maintainers already.

Happy to tweak as needed.