### PR TITLE
Fix typo on footer template.

### DIFF
--- a/trac-env/templates/site_footer.html
+++ b/trac-env/templates/site_footer.html
@@ -71,7 +71,7 @@
         <li class="design"><span>Design by</span> <a class="threespot" href="http://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/"></a></li>
       </ul>
       <p class="copyright">&copy; 2005-${date.today().year}
-        <a href="https://djangoproject.com/foundation/"> Django SoftwareFoundation</a>
+        <a href="https://djangoproject.com/foundation/"> Django Software Foundation</a>
         unless otherwise noted. Django is a
         <a href="https://djangoproject.com/trademarks/">registered trademark</a>
         of the Django Software Foundation.


### PR DESCRIPTION
Changes **Django SoftwareFoundation** to **Django Software Foundation**. The website [https://www.djangoproject.com/](https://www.djangoproject.com/) also shows software foundation as two different words.