### PR TITLE
Add the new feature ideas tracker to the new ticket readme

### DIFF
--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -12,7 +12,7 @@
       Report bugs and suggest documentation changes using this ticket tracker.
     </li>
     <li>
-      New feature proposals should be created on the <a href="https://github.com/django/new-features/issues/new/choose">new feature idea tracker</a>. The <a href="https://github.com/orgs/django/projects/24">project board view</a> can be used to view existing ideas and their progress..
+      New feature proposals should be created on the <a href="https://github.com/django/new-features/issues/new/choose">new feature idea tracker</a>. The <a href="https://github.com/orgs/django/projects/24">project board view</a> can be used to view existing ideas and their progress.
       Please include links to relevant discussions from the forum (or other sources).
       If the feature is approved for Django core, a feature ticket may be created here on Trac.
     </li>

--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -12,7 +12,7 @@
       Report bugs and suggest documentation changes using this ticket tracker.
     </li>
     <li>
-      New feature proposals should be created on the <a href="https://github.com/orgs/django/projects/24/">new feature idea tracker</a>.
+      New feature proposals should be created on the <a href="https://github.com/django/new-features/issues/new/choose">new feature idea tracker</a>. The <a href="https://github.com/orgs/django/projects/24">project board view</a> can be used to view existing ideas and their progress..
       Please include links to relevant discussions from the forum (or other sources).
       If the feature is approved for Django core, a feature ticket may be created here.
     </li>

--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -12,9 +12,9 @@
       Report bugs and suggest documentation changes using this ticket tracker.
     </li>
     <li>
-      New feature proposals should first be discussed on the <a href="https://forum.djangoproject.com/c/internals/5">Django Forum</a>.
-      Once feedback has been gathered, you can use this ticket tracker to open a ticket for the new feature.
+      New feature proposals should be created on the <a href="https://github.com/orgs/django/projects/24/">new feature idea tracker</a>.
       Please include links to relevant discussions from the forum (or other sources).
+      If the feature is approved for Django core, a feature ticket may be created here.
     </li>
     <li>
       Don't use the ticket system for

--- a/trac-env/templates/custom_ticket.html
+++ b/trac-env/templates/custom_ticket.html
@@ -14,7 +14,7 @@
     <li>
       New feature proposals should be created on the <a href="https://github.com/django/new-features/issues/new/choose">new feature idea tracker</a>. The <a href="https://github.com/orgs/django/projects/24">project board view</a> can be used to view existing ideas and their progress..
       Please include links to relevant discussions from the forum (or other sources).
-      If the feature is approved for Django core, a feature ticket may be created here.
+      If the feature is approved for Django core, a feature ticket may be created here on Trac.
     </li>
     <li>
       Don't use the ticket system for


### PR DESCRIPTION
Updates the new ticket readme to point users to use the experimental new feature idea tracker introduced by the Steering Council.