### PR TITLE
Fixed #259 -- Add quick links for ticket query filters

### DIFF
--- a/scss/trachacks.scss
+++ b/scss/trachacks.scss
@@ -434,3 +434,20 @@ div[role="main"]{
     }
   }
 }
+
+#query-quick-links {
+  li {
+    display: inline-block;
+    margin-right: 10px;
+  }
+
+  li:before {
+    content: '\00a0\2022\00a0\00a0';
+    color:rgba(0,0,0,0.5);
+    font-size:11px;
+  }
+
+  li:first-child:before {
+    content: '';
+  }
+}

--- a/trac-env/htdocs/queryhacks.js
+++ b/trac-env/htdocs/queryhacks.js
@@ -4,20 +4,32 @@
 
 $(function () {
     let stage_quick_links = {
-        'Needs Triage': '/query?stage=Unreviewed&status=!closed&order=priority',
-        'Needs PR Review': '/query?has_patch=1&needs_better_patch=0&needs_docs=0&needs_tests=0&stage=Accepted&status=!closed&order=changetime&desc=1',
-        'Waiting On Author': '/query?has_patch=1&needs_better_patch=1&stage=Accepted&status=!closed&order=priority',
-        'Ready For Merger': '/query?stage=Ready+for+checkin&status=!closed&order=priority',
-        'Release Blockers': '/query?severity=Release+blocker&status=assigned&status=new&order=version&col=id&col=summary&col=owner&col=component&col=version&col=changetime&col=has_patch',
+      'Unreviewed': '/query?stage=Unreviewed&status=!closed&order=priority',
+      'Needs Patch': '/query?stage=Unreviewed&status=!closed&order=priority',
+      'Needs PR Review': '/query?has_patch=1&needs_better_patch=0&needs_docs=0&needs_tests=0&stage=Accepted&status=!closed&order=changetime&desc=1',
+      'Waiting On Author': '/query?has_patch=1&needs_better_patch=1&stage=Accepted&status=!closed&order=priority',
+      'Ready For Checkin': '/query?stage=Ready+for+checkin&status=!closed&order=priority',
+    }
+    let other_quick_links = {
+      'Needs Info': '/query?resolution=needsinfo&order=priority',
+      'Someday/Maybe': '/query?stage=Someday%2FMaybe&status=!closed&order=priority',
+      'Release Blockers': '/query?severity=Release+blocker&status=assigned&status=new&order=version&col=id&col=summary&col=owner&col=component&col=version&col=changetime&col=has_patch',
     }
 
     $('#query').after(
       "<div id='query-quick-links'>" +
-        '<p>Quick Links</p>' +
+        '<span>Queues:</span>' +
         '<ul>' +
         Object.keys(stage_quick_links).map(function (stage) {
             console.log(stage, stage_quick_links[stage]);
             return '<li><a href="' + stage_quick_links[stage] + '">' + stage + '</a></li>';
+        }).join('') +
+        '</ul>' +
+        '<span>More tickets:</span>' +
+        '<ul>' +
+        Object.keys(other_quick_links).map(function (stage) {
+            console.log(stage, other_quick_links[stage]);
+            return '<li><a href="' + other_quick_links[stage] + '">' + stage + '</a></li>';
         }).join('') +
         '</ul>' +
       '</div>',

--- a/trac-env/htdocs/queryhacks.js
+++ b/trac-env/htdocs/queryhacks.js
@@ -1,0 +1,25 @@
+//
+// Hacks for the ticket page.
+//
+
+$(function () {
+    let stage_quick_links = {
+        'Needs Triage': '/query?stage=Unreviewed&status=!closed&order=priority',
+        'Needs PR Review': '/query?has_patch=1&needs_better_patch=0&needs_docs=0&needs_tests=0&stage=Accepted&status=!closed&order=changetime&desc=1',
+        'Waiting On Author': '/query?has_patch=1&needs_better_patch=1&stage=Accepted&status=!closed&order=priority',
+        'Ready For Merger': '/query?stage=Ready+for+checkin&status=!closed&order=priority',
+        'Release Blockers': '/query?severity=Release+blocker&status=assigned&status=new&order=version&col=id&col=summary&col=owner&col=component&col=version&col=changetime&col=has_patch',
+    }
+
+    $('#query').after(
+      "<div id='query-quick-links'>" +
+        '<p>Quick Links</p>' +
+        '<ul>' +
+        Object.keys(stage_quick_links).map(function (stage) {
+            console.log(stage, stage_quick_links[stage]);
+            return '<li><a href="' + stage_quick_links[stage] + '">' + stage + '</a></li>';
+        }).join('') +
+        '</ul>' +
+      '</div>',
+    );
+});

--- a/trac-env/templates/site_head.html
+++ b/trac-env/templates/site_head.html
@@ -14,3 +14,6 @@
 # if req.path_info.startswith('/ticket/'):
   <script type="text/javascript" src="${href.chrome('site/tickethacks.js')}"></script>
 # endif
+# if req.path_info.startswith('/query'):
+  <script type="text/javascript" src="${href.chrome('site/queryhacks.js')}"></script>
+# endif


### PR DESCRIPTION
Adding quick links to the query page. Links are pulled from the "Reports" tab.

To Do:
- [ ] Currently uses javascript to add the links, but maybe need to iterate and add in html instead.