### PR TITLE
Bump base Docker image to Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.11-slim-bookworm
+FROM python:3.11-slim-trixie
 
 # set work directory
 WORKDIR /code
@@ -20,13 +20,13 @@ RUN apt-get update \
     && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y\
     && apt-get install --assume-yes --no-install-recommends postgresql-client-14\
     && apt-get purge --assume-yes --auto-remove gnupg\
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get distclean
 
 # install deb packages
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         make \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get distclean
 
 # install python dependencies
 COPY ./requirements.txt ./requirements.txt


### PR DESCRIPTION
Similar to https://github.com/django/djangoproject.com/pull/2165

https://www.debian.org/News/2025/20250809

---

> distclean (and the dist-clean alias)
>
> distclean removes all files under /var/lib/apt/lists except Release, Release.gpg, and InRelease. It can be used for example, when finalizing images distributed to users. The release files are kept for security reasons, to prevent various types of attacks.