### PR TITLE
Bump Django to 6.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       rev: "1.29.0"
       hooks:
           - id: django-upgrade
-            args: [--target-version, "5.2"]
+            args: [--target-version, "6.0"]
 
     - repo: https://github.com/psf/black
       rev: 25.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # rest is needed to support wiki pages written in rst
 Trac[babel, pygments, rest]==1.6.0
 psycopg2==2.9.9 --no-binary=psycopg2
-Django==5.2.9
+Django==6.0.1
 libsass==0.23.0
 
 # Optional Trac dependencies that make DeprecationWarning go away.


### PR DESCRIPTION
Fixes #285

Follows https://github.com/django/djangoproject.com/pull/2394/ and matches the main site's Django version