### PR TITLE
Update checkout/actions to v6

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Log in to the Container registry
               uses: docker/login-action@v3

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,6 +18,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: black
               uses: psf/black@stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - uses: actions/setup-python@v5
               with:
                   python-version: "3.11"
@@ -37,7 +37,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - uses: actions/setup-python@v5
               with:
                   python-version: "3.11"
@@ -54,7 +54,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - uses: actions/setup-python@v5
               with:
                   python-version: "3.11"


### PR DESCRIPTION
v6 major version had 3 releases so far:
* https://github.com/actions/checkout/releases/tag/v6.0.0 
* https://github.com/actions/checkout/releases/tag/v6.0.1
* https://github.com/actions/checkout/releases/tag/v6.0.2