### PR TITLE
Match CI black version to git hooks

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -20,4 +20,4 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
             - name: black
-              uses: psf/black@stable
+              uses: psf/black@25.9.0


### PR DESCRIPTION
The goal is to prevent failures like https://github.com/django/code.djangoproject.com/actions/runs/21645467837 . I matched the version from git hook config, instead of the latest one. We can handle the update separately.