### PR TITLE
Add missing text in footer link for andrevv

### DIFF
--- a/trac-env/templates/site_footer.html
+++ b/trac-env/templates/site_footer.html
@@ -68,7 +68,7 @@
         <li>
           <span>Hosting by</span> <a class="in-kind-donors" href="https://www.djangoproject.com/fundraising/#in-kind-donors">In-kind donors</a>
         </li>
-        <li class="design"><span>Design by</span> <a class="threespot" href="http://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/"></a></li>
+        <li class="design"><span>Design by</span> <a class="threespot" href="http://www.threespot.com">Threespot</a> <span class="ampersand">&amp;</span> <a class="andrevv" href="http://andrevv.com/">andrevv</a></li>
       </ul>
       <p class="copyright">&copy; 2005-${date.today().year}
         <a href="https://djangoproject.com/foundation/"> Django Software Foundation</a>


### PR DESCRIPTION
Without this, the URL is raised as an error by accessibility checkers (see https://github.com/laymonage/djangoproject.com/actions/runs/24835671645/job/73610565131#step:6:50)

This is equivalent to https://github.com/django/djangoproject.com/pull/1040.