### PR TITLE
Fixed local Docker setup and asset porting docs

### DIFF
--- a/DjangoPlugin/tracdjangoplugin/wsgi.py
+++ b/DjangoPlugin/tracdjangoplugin/wsgi.py
@@ -1,12 +1,12 @@
 import os
 
-import trac.web.main
-
-application = trac.web.main.dispatch_request
-
 import django
 
 django.setup()
+
+import trac.web.main
+
+application = trac.web.main.dispatch_request
 
 # Massive hack to make Trac fast, otherwise every git call tries to close ulimit -n (1e6) fds
 # Python 3 would perform better here, but we are still on 2.7 for Trac, so leak fds for now.

--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ that can help:
 * Use ``trac-admin ./trac-env/ permission add anonymous TRAC_ADMIN``
   to give all permissions to the anonymous user.
 * Use the command ``DJANGO_SETTINGS_MODULE=tracdjangoplugin.settings TRAC_ENV=`pwd`/trac-env gunicorn tracdjangoplugin.wsgi:application --bind 0.0.0.0:9000 --workers=1 --reload`` to serve Trac locally.
-* If you've modified the ``trackhack.scss`` file, use
-  ``sassc scss/trachacks.scss trac-env/htdocs/css/trachacks.css -s compressed``
-  to compile it to CSS.
+* If you've modified the ``trachacks.scss`` file, use
+  ``make compile-scss`` to compile it to CSS. This requires ``pysassc``, which
+  is provided by the ``libsass`` Python package.
 
 Using Docker
 ------------
@@ -54,13 +54,16 @@ Assumes that `code.djangoproject.com` and `djangoproject.com` are stored in the
 same directory (adjust paths if needed).
 
 1. Copy the generated CSS:
-   ``cp ../djangoproject.com/static/css/*.css trac-env/htdocs/css/``
-2. Copy _utils.scss (needed by trackahacks.scss):
-   ``cp ../djangoproject.com/static/scss/_utils.scss scss/``
+   ``cp ../djangoproject.com/djangoproject/static/css/*.css trac-env/htdocs/css/``
+2. Copy _utils.scss (needed by trachacks.scss):
+   ``cp ../djangoproject.com/djangoproject/scss/_utils.scss scss/``
 3. Copy the javascript directory:
-   ``cp -rT ../djangoproject.com/static/js trac-env/htdocs/js``
+   ``cp -rT ../djangoproject.com/djangoproject/static/js trac-env/htdocs/js``
 4. Compile trackhacks.scss:
    ``make compile-scss``
+
+   If you're using Docker and don't have ``pysassc`` installed locally, run:
+   ``docker compose run --rm --entrypoint make trac compile-scss``
 
 How to recreate `trac.sql` after upgrading Trac
 -----------------------------------------------

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,16 @@ for var in "${!TRAC_INI_@}"; do
     sed -i "s;^${var:9} = .*;${var:9} = ${!var};" /code/trac-env/conf/trac.ini
 done
 
+if ! python <<'PY'
+from importlib.metadata import entry_points
+
+plugins = entry_points(group="trac.plugins")
+raise SystemExit(not any(plugin.name == "tracdjangoplugin" for plugin in plugins))
+PY
+then
+    python -m pip install --no-deps -e ./DjangoPlugin
+fi
+
 if [ "x$TRAC_COLLECT_STATIC" = 'xon' ]; then
     # Collect trac static files to be served by nginx
     trac-admin /code/trac-env/ deploy ./static/


### PR DESCRIPTION
This updates the local setup docs and Docker startup path for `code.djangoproject.com`.

While following the README locally, I ran into a few issues:

- The CSS porting paths pointed to `../djangoproject.com/static/...`, but current `djangoproject.com` stores these under `../djangoproject.com/djangoproject/...`.
- `make compile-scss` failed on the host because `pysassc` was not installed, even though the Docker image already has the `libsass` dependency.
- Copying current `djangoproject.com` assets can make the local Trac header look broken, because the current website CSS expects newer header markup than the Trac templates use.
- The Docker bind mount can hide the editable install metadata for `DjangoPlugin`, causing Trac to fail loading `CustomWikiModule`.
